### PR TITLE
fix(build): migrate deps and usbipd glue for idf6.

### DIFF
--- a/components/usbipd/CMakeLists.txt
+++ b/components/usbipd/CMakeLists.txt
@@ -31,8 +31,13 @@ set(COMPONENT_REQUIRES
     "freertos"
     "log"
     "lwip"
-    "newlib"
 )
+
+if("${IDF_VERSION_MAJOR}" VERSION_GREATER_EQUAL "6")
+    list(APPEND COMPONENT_REQUIRES "esp_libc")
+else()
+    list(APPEND COMPONENT_REQUIRES "newlib")
+endif()
 
 set(COMPONENT_PRIV_REQUIRES
     "debug_probe"

--- a/components/usbipd/platform/espidf_os.c
+++ b/components/usbipd/platform/espidf_os.c
@@ -503,7 +503,7 @@ static osal_ops_t espidf_ops = {
 /**
  * Auto-register ESP-IDF implementation
  */
-__attribute__((section(".usbip.init"), used)) void default_os_register(void)
+__attribute__((used)) void default_os_register(void)
 {
     osal_register("espidf", &espidf_ops);
 }

--- a/components/usbipd/platform/espidf_transport.c
+++ b/components/usbipd/platform/espidf_transport.c
@@ -262,7 +262,7 @@ static struct usbip_transport trans = {.priv = &priv,
                                        .stop = tcp_stop,
                                        .destroy = tcp_destroy};
 
-__attribute__((section(".usbip.init"), used)) void default_transport_register(void)
+__attribute__((used)) void default_transport_register(void)
 {
     transport_register("espidf", &trans);
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -6,6 +6,22 @@ set(usb_srcs
         "usb/usb_desc.c")
 endif()
 
+set(main_requires
+        espressif__cjson
+        esp_wifi
+        esp_http_server
+        nvs_flash
+        Program
+        usbipd
+)
+
+# Starting from esp-idf v5.3, UART driver is moved to a separate component.
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.3")
+        list(APPEND main_requires esp_driver_uart)
+else()
+        list(APPEND main_requires driver)
+endif()
+
 idf_component_register(SRCS "main.cpp"
                         # Disk
                         "disk/disk.c"
@@ -26,6 +42,8 @@ idf_component_register(SRCS "main.cpp"
                         "programmer/prog_offline.cpp"
                         # WiFi
                         "wifi.c"
+                       REQUIRES ${main_requires}
+                       PRIV_REQUIRES app_update spi_flash
                        INCLUDE_DIRS . usb serial web programmer disk
                        EMBED_FILES "../html/root.html"
                         "../html/favicon.ico"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,11 +1,13 @@
-## IDF Component Manager Manifest File
+# IDF Component Manager Manifest File
 dependencies:
-  espressif/tinyusb: 
-     version: ^0.18.0~2
-     rules:
+  espressif/tinyusb:
+    version: "^0.18.0~2"
+    rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
-  idf: ^5.0
-  espressif/esp_tinyusb: 
-     version: "^1.4.2"
-     rules:
+  idf: "^5.0"
+  espressif/esp_tinyusb:
+    version: "^1.4.2"
+    rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
+  espressif/cjson:
+    version: "^1.7.19~2"


### PR DESCRIPTION
 Hi, I want to add compitability for idf v6.0.1. tested with idf 5.2.7, 5.5.4, 6.0.1